### PR TITLE
Bug fix

### DIFF
--- a/vae_quant.py
+++ b/vae_quant.py
@@ -196,9 +196,9 @@ class VAE(nn.Module):
         M = batch_size - 1
         strat_weight = (N - M) / (N * M)
         W = torch.Tensor(batch_size, batch_size).fill_(1 / M)
-        W.view(-1)[::M+1] = 1 / N
-        W.view(-1)[1::M+1] = strat_weight
-        W[M-1, 0] = strat_weight
+        W.view(-1)[::batch_size+1] = 1 / N
+        W.view(-1)[1::batch_size+1] = strat_weight
+        W[batch_size-1, 0] = strat_weight
         return W.log()
 
     def elbo(self, x, dataset_size):


### PR DESCRIPTION
I think I have found a bug in _log_importance_weight_matrix method.

Striding (M+1) is just batch_size, which jumps rows while the column index is same (vertical move), but I think the intended implementation is a diagonal move on the matrix.